### PR TITLE
Fix pdf.js worker import

### DIFF
--- a/src/components/TextUploadModal.tsx
+++ b/src/components/TextUploadModal.tsx
@@ -5,6 +5,12 @@ import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { Loader2 } from 'lucide-react';
 import { toast } from '@/components/ui/use-toast';
+import * as pdfjsLib from 'pdfjs-dist';
+
+(async () => {
+  const workerSrc = await import('pdfjs-dist/build/pdf.worker.min.mjs?url');
+  pdfjsLib.GlobalWorkerOptions.workerSrc = workerSrc.default;
+})();
 
 interface TextUploadModalProps {
   open: boolean;


### PR DESCRIPTION
## Summary
- update pdf.js worker import to `pdf.worker.min.mjs` and configure GlobalWorkerOptions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bee987509c832bbd465369ec3352cf